### PR TITLE
Tests - add _open to stub

### DIFF
--- a/src/test_cpp/test_cpp_exceptions/stub.cpp
+++ b/src/test_cpp/test_cpp_exceptions/stub.cpp
@@ -76,6 +76,15 @@ extern "C" int _close(int file)
 }
 
 // This stub function is required by stdlib
+extern "C" int _open(const char *name, int flags, int mode)
+{
+    static_cast<void>(name);
+    static_cast<void>(flags);
+    static_cast<void>(mode);
+    return -1;
+}
+
+// This stub function is required by stdlib
 extern "C" int _fstat(int file, struct stat *st)
 {
     static_cast<void>(file);

--- a/src/test_cpp/test_cpp_vector/stub.cpp
+++ b/src/test_cpp/test_cpp_vector/stub.cpp
@@ -91,6 +91,15 @@ extern "C" int _isatty(int file)
 }
 
 // This stub function is required by stdlib
+extern "C" int _open(const char *name, int flags, int mode)
+{
+    static_cast<void>(name);
+    static_cast<void>(flags);
+    static_cast<void>(mode);
+    return -1;
+}
+
+// This stub function is required by stdlib
 extern "C" int _lseek(int file, int ptr, int dir)
 {
     static_cast<void>(file);


### PR DESCRIPTION
Not sure if master or develop branch?

@ajneu already created an issue #1. It's still valid thus trying to push this upstream. It fails now with different errors. Thanks !

First, I am cross compiling this on windows - cmake fails with a cmaketest, I made it working but don't like it, have to spend more time to find a proper solution (I updated to cmake 3.5.0-rc2 because of their updates to cmake c/cxx flags to enforce compiler).

Second, after applying this patch, I get lot of errors like this:

```
Function.cpp:45:1: error: non-constant condition for static assertion
 static_assert(&pSel->entries[0] == reinterpret_cast<volatile SingleSelWord*>(0x20200000),
```

I'll look at them to see what I can do.

Using cmake 3.5.0-rc2, arm-none-eabi-gcc 5.2.1 20151202
