### PR TITLE
forcing compiler is deprecated in cmake v3.6 and beyond

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,14 +14,25 @@ include (AR_AllExtras)
 embxx_add_cpp11_support ()
 embxx_set_default_compiler_options ()
 
-set (CMAKE_SYSTEM_NAME "RPi")
-if ("${CROSS_COMPILE}" STREQUAL "")
-    set (CROSS_COMPILE "arm-none-eabi-")
-endif()
+set (CMAKE_SYSTEM_NAME "Generic")               ## possibly this needs to be in the else() branch below (?)
 
-set (CMAKE_C_COMPILER "${CROSS_COMPILE}gcc")
-set (CMAKE_CXX_COMPILER "${CROSS_COMPILE}g++")
-set (CMAKE_ASM_COMPILER "${CROSS_COMPILE}as")
+set(toolchain   ""      CACHE FILEPATH     "")  ## -Dtoolchain=/my/path/to/toolchain_file
+if (toolchain AND EXISTS ${toolchain})
+  message("==> Including toolchain_file ${toolchain}")
+  include(${toolchain})
+else()
+
+  if ("${CROSS_COMPILE}" STREQUAL "")
+    set (CROSS_COMPILE "arm-none-eabi-")
+  endif()
+
+  set (CMAKE_C_COMPILER   "${CROSS_COMPILE}gcc")
+  set (CMAKE_CXX_COMPILER "${CROSS_COMPILE}g++")
+  set (CMAKE_ASM_COMPILER "${CROSS_COMPILE}as")
+  set (CMAKE_AR           "${CROSS_COMPILE}ar")
+  set (CMAKE_RANLIB       "${CROSS_COMPILE}ranlib")
+
+endif()
 
 # for libraries and headers in the target directories
 set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required (VERSION 2.8)
 
 if (CMAKE_TOOLCHAIN_FILE AND EXISTS ${CMAKE_TOOLCHAIN_FILE})
     message("==> Loading \${CMAKE_TOOLCHAIN_FILE} == ${CMAKE_TOOLCHAIN_FILE}")
+    if(NOT DEFINED CMAKE_CROSSCOMPILING)
+        message(FATAL_ERROR "Toolchain file must define CMAKE_SYSTEM_NAME, typically: set (CMAKE_SYSTEM_NAME \"Generic\")")
+    endif()
 else()
 
     set (CMAKE_SYSTEM_NAME "Generic")
@@ -9,9 +12,15 @@ else()
         set (CROSS_COMPILE "arm-none-eabi-")
     endif()
 
-    include(CMakeForceCompiler)
-    cmake_force_c_compiler(  "${CROSS_COMPILE}gcc" GNU)
-    cmake_force_cxx_compiler("${CROSS_COMPILE}g++" GNU)
+    if (CMAKE_VERSION VERSION_LESS 3.6)
+        include(CMakeForceCompiler)
+        cmake_force_c_compiler(  "${CROSS_COMPILE}gcc" GNU)
+        cmake_force_cxx_compiler("${CROSS_COMPILE}g++" GNU)
+    else()
+        set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+        set(CMAKE_C_COMPILER   "${CROSS_COMPILE}gcc")
+        set(CMAKE_CXX_COMPILER "${CROSS_COMPILE}g++")
+    endif()
 
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,22 @@
 cmake_minimum_required (VERSION 2.8)
+
+if (CMAKE_TOOLCHAIN_FILE AND EXISTS ${CMAKE_TOOLCHAIN_FILE})
+    message("==> Loading \${CMAKE_TOOLCHAIN_FILE} == ${CMAKE_TOOLCHAIN_FILE}")
+else()
+
+    set (CMAKE_SYSTEM_NAME "Generic")
+    if ("${CROSS_COMPILE}" STREQUAL "")
+        set (CROSS_COMPILE "arm-none-eabi-")
+    endif()
+
+    include(CMakeForceCompiler)
+    cmake_force_c_compiler(  "${CROSS_COMPILE}gcc" GNU)
+    cmake_force_cxx_compiler("${CROSS_COMPILE}g++" GNU)
+
+endif()
+
+#########
+
 project ("embxx_on_rpi")
 
 set (EXTERNALS_DIR "${CMAKE_SOURCE_DIR}/external")
@@ -14,26 +32,6 @@ include (AR_AllExtras)
 embxx_add_cpp11_support ()
 embxx_set_default_compiler_options ()
 
-set (CMAKE_SYSTEM_NAME "Generic")
-
-set(CUSTOM_TOOLCHAIN "" CACHE FILEPATH "Choose custom toolchain file")
-if (CUSTOM_TOOLCHAIN AND EXISTS ${CUSTOM_TOOLCHAIN})
-  message("==> Including CUSTOM_TOOLCHAIN_file ${CUSTOM_TOOLCHAIN}")
-  include(${CUSTOM_TOOLCHAIN})
-else()
-
-  if ("${CROSS_COMPILE}" STREQUAL "")
-    set (CROSS_COMPILE "arm-none-eabi-")
-  endif()
-
-  set (CMAKE_C_COMPILER   "${CROSS_COMPILE}gcc")
-  set (CMAKE_CXX_COMPILER "${CROSS_COMPILE}g++")
-  set (CMAKE_ASM_COMPILER "${CROSS_COMPILE}as")
-  set (CMAKE_AR           "${CROSS_COMPILE}ar")
-  set (CMAKE_RANLIB       "${CROSS_COMPILE}ranlib")
-
-endif()
-
 # for libraries and headers in the target directories
 set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
@@ -47,3 +45,9 @@ set (STDLIB_STUB_LIB_NAME "stdlib_stub")
 
 add_subdirectory (src)
 
+message(STATUS "Found C compiler: ${CMAKE_C_COMPILER}")
+message(STATUS "Found C++ compiler: ${CMAKE_CXX_COMPILER}")
+message(STATUS "Found ar: ${CMAKE_AR}")
+message(STATUS "Found ranlib: ${CMAKE_RANLIB}")
+message(STATUS "Found objcopy: ${CMAKE_OBJCOPY}")
+message(STATUS "Found objdump: ${CMAKE_OBJDUMP}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,12 +14,12 @@ include (AR_AllExtras)
 embxx_add_cpp11_support ()
 embxx_set_default_compiler_options ()
 
-set (CMAKE_SYSTEM_NAME "Generic")               ## possibly this needs to be in the else() branch below (?)
+set (CMAKE_SYSTEM_NAME "Generic")
 
-set(toolchain   ""      CACHE FILEPATH     "")  ## -Dtoolchain=/my/path/to/toolchain_file
-if (toolchain AND EXISTS ${toolchain})
-  message("==> Including toolchain_file ${toolchain}")
-  include(${toolchain})
+set(CUSTOM_TOOLCHAIN "" CACHE FILEPATH "Choose custom toolchain file")
+if (CUSTOM_TOOLCHAIN AND EXISTS ${CUSTOM_TOOLCHAIN})
+  message("==> Including CUSTOM_TOOLCHAIN_file ${CUSTOM_TOOLCHAIN}")
+  include(${CUSTOM_TOOLCHAIN})
 else()
 
   if ("${CROSS_COMPILE}" STREQUAL "")

--- a/README
+++ b/README
@@ -38,7 +38,14 @@ How to compile
        include(CMakeForceCompiler)
        cmake_force_c_compiler(arm-none-eabi-gcc)
        cmake_force_cxx_compiler(arm-none-eabi-g++)
+
+   For CMake version 3.6 or newer it can look like this:
    
+       set (CMAKE_SYSTEM_NAME "Generic")
+       set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+       set(CMAKE_C_COMPILER   arm-none-eabi-gcc)
+       set(CMAKE_CXX_COMPILER arm-none-eabi-g++)
+
 3. Build the binaries:
    > make
    

--- a/README
+++ b/README
@@ -30,14 +30,14 @@ How to compile
    
    It is also possible to provide a separate toolchain file instead of 
    specifying CROSS_COMPILE prefix.
-   > cmake -DCMAKE_BUILD_TYPE=Release -DCUSTOM_TOOLCHAIN=/path/to/toolchain/file ..
+   > cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=/path/to/toolchain/file ..
    
-   The custom toolchain file is expected to set the following variables:
-   - CMAKE_C_COMPILER
-   - CMAKE_CXX_COMPILER
-   - CMAKE_ASM_COMPILER
-   - CMAKE_AR
-   - CMAKE_RANLIB
+   The custom toolchain file is expected to be similiar to this example:
+
+       set (CMAKE_SYSTEM_NAME "Generic")
+       include(CMakeForceCompiler)
+       cmake_force_c_compiler(arm-none-eabi-gcc)
+       cmake_force_cxx_compiler(arm-none-eabi-g++)
    
 3. Build the binaries:
    > make

--- a/README
+++ b/README
@@ -26,7 +26,19 @@ How to compile
    build type please use CMAKE_BUILD_TYPE definition when using cmake utility:
    > cmake -DCMAKE_BUILD_TYPE=Release -DCROSS_COMPILE=/opt/arm-none-eabi-2013.05/bin/arm-none-eabi- ..
    
-   Please refer to CMake documentation for details about its build types
+   Please refer to CMake documentation for details about its build types.
+   
+   It is also possible to provide a separate toolchain file instead of 
+   specifying CROSS_COMPILE prefix.
+   > cmake -DCMAKE_BUILD_TYPE=Release -DCUSTOM_TOOLCHAIN=/path/to/toolchain/file ..
+   
+   The custom toolchain file is expected to set the following variables:
+   - CMAKE_C_COMPILER
+   - CMAKE_CXX_COMPILER
+   - CMAKE_ASM_COMPILER
+   - CMAKE_AR
+   - CMAKE_RANLIB
+   
 3. Build the binaries:
    > make
    
@@ -34,6 +46,7 @@ How to compile
    > VERBOSE=1 make
 4. The image of every compiled application will be:
    <embxx_build_dir>/image/<app_name>/kernel.img
+   
    
 Applications
 -------------------

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,13 +12,13 @@ function (link_app tgt)
         TARGET ${tgt}
         POST_BUILD
         COMMAND 
-            ${CROSS_COMPILE}objcopy $<TARGET_FILE:${tgt}> -O binary 
+            ${CMAKE_OBJCOPY} $<TARGET_FILE:${tgt}> -O binary
                                         $<TARGET_FILE_DIR:${tgt}>/kernel.img
         COMMAND 
-            ${CROSS_COMPILE}objdump -D -S $<TARGET_FILE:${tgt}> > 
+            ${CMAKE_OBJDUMP} -D -S $<TARGET_FILE:${tgt}> >
                                         $<TARGET_FILE_DIR:${tgt}>/kernel.list
         COMMAND 
-            ${CROSS_COMPILE}objdump -t $<TARGET_FILE:${tgt}> > 
+            ${CMAKE_OBJDUMP} -t $<TARGET_FILE:${tgt}> >
                                         $<TARGET_FILE_DIR:${tgt}>/kernel.syms
         COMMAND 
             ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/image/${tgt}

--- a/src/app/app_i2c0_eeprom/main.cpp
+++ b/src/app/app_i2c0_eeprom/main.cpp
@@ -147,7 +147,7 @@ void readFunc(
     embxx::io::writeBig(address, bufIter);
 
     eeprom.asyncWrite(buf, sizeof(address),
-        [&eeprom, address, buf, bufSize, maxAddress](const embxx::error::ErrorStatus& err, std::size_t bytesTransferred)
+        [&eeprom, address, buf, bufSize, maxAddress](const embxx::error::ErrorStatus& err, std::size_t bytesWritten)
         {
             auto& log = System::instance().log();
             if (err) {
@@ -158,28 +158,28 @@ void readFunc(
                 return;
             }
 
-            static_cast<void>(bytesTransferred);
-            GASSERT(bytesTransferred == sizeof(address));
+            static_cast<void>(bytesWritten);
+            GASSERT(bytesWritten == sizeof(address));
             std::size_t readCount = std::min(bufSize - sizeof(address), std::size_t(maxAddress - address));
 
             eeprom.asyncRead(&buf[sizeof(address)], readCount,
-                [&eeprom, address, buf, bufSize, maxAddress, readCount](const embxx::error::ErrorStatus& err, std::size_t bytesTransferred)
+                [&eeprom, address, buf, bufSize, maxAddress, readCount](const embxx::error::ErrorStatus& err2, std::size_t bytesRead)
                 {
-                    auto& log = System::instance().log();
+                    auto& log2 = System::instance().log();
 
-                    if (err) {
-                        SLOG(log, embxx::util::log::Error,
+                    if (err2) {
+                        SLOG(log2, embxx::util::log::Error,
                             "R (0x" << embxx::io::hex << embxx::io::setw(0) <<
                             eeprom.getDeviceId() << ") : Failed to read with error " <<
-                            err);
+                            err2);
                         return;
                     }
 
-                    static_cast<void>(bytesTransferred);
-                    GASSERT(bytesTransferred == readCount);
+                    static_cast<void>(bytesRead);
+                    GASSERT(bytesRead == readCount);
 
                     auto readBuf = &buf[sizeof(address)];
-                    SLOG(log, embxx::util::log::Info,
+                    SLOG(log2, embxx::util::log::Info,
                         "R (0x" << embxx::io::hex << embxx::io::setw(0) <<
                         eeprom.getDeviceId() << ") : [0x" <<
                         embxx::io::setfill('0') << embxx::io::setw(sizeof(address) * 2) <<
@@ -190,7 +190,7 @@ void readFunc(
                         embxx::io::setw(0) << embxx::io::dec << readCount << " bytes");
 
                     if (!verifySeqCorrect(&readBuf[0], readCount)) {
-                        SLOG(log, embxx::util::log::Error,
+                        SLOG(log2, embxx::util::log::Error,
                             "Read mismatch for 0x" << eeprom.getDeviceId() << "!!!");
                         return;
                     }

--- a/src/app/app_uart1_morse/Morse.h
+++ b/src/app/app_uart1_morse/Morse.h
@@ -105,10 +105,10 @@ private:
                 if (*seq != End) {
                     timer_.asyncWait(
                         std::chrono::milliseconds(Duration(Spacing)),
-                        [this, seq](const embxx::error::ErrorStatus& es)
+                        [this, seq](const embxx::error::ErrorStatus& es2)
                         {
-                            static_cast<void>(es);
-                            GASSERT(!es);
+                            static_cast<void>(es2);
+                            GASSERT(!es2);
                             nextSyllable(seq);
                         });
                     return;
@@ -116,10 +116,10 @@ private:
 
                 timer_.asyncWait(
                     std::chrono::milliseconds(Duration(InterSpacing)),
-                    [this](const embxx::error::ErrorStatus& es)
+                    [this](const embxx::error::ErrorStatus& es3)
                     {
-                        static_cast<void>(es);
-                        GASSERT(!es);
+                        static_cast<void>(es3);
+                        GASSERT(!es3);
                         nextLetter();
                     });
             });

--- a/src/asm/CMakeLists.txt
+++ b/src/asm/CMakeLists.txt
@@ -18,4 +18,3 @@ embxx_add_asm_flags ("-march=armv6z")
 enable_language (ASM)
 
 lib_startup ()
-

--- a/src/component/Led.h
+++ b/src/component/Led.h
@@ -46,10 +46,10 @@ private:
 
 // Implementation
 template <typename TGpio, bool TOnState>
-Led<TGpio, TOnState>::Led(Gpio& gpio, PinIdType pin, bool isOn)
+Led<TGpio, TOnState>::Led(Gpio& gpio, PinIdType pin, bool isOnVal)
     : gpio_(gpio),
       pin_(pin),
-      isOn_(isOn)
+      isOn_(isOnVal)
 {
     gpio_.configDir(pin, Gpio::Dir_Output);
 }

--- a/src/device/Gpio.h
+++ b/src/device/Gpio.h
@@ -78,21 +78,21 @@ public:
                 [this](){
                     WordsBundle bundle = *pGPEDS;
                     *pGPEDS = bundle; // clear all the reported interrupts
-                    for (PinIdType i = 0U; i < NumOfLines; ++i) {
-                        auto* entry = idxToEntry(i, &bundle);
-                        auto mask = idxToEntryBitmask(i);
+                    for (PinIdType id = 0U; id < NumOfLines; ++id) {
+                        auto* entry = idxToEntry(id, &bundle);
+                        auto mask = idxToEntryBitmask(id);
                         if ((*entry & mask) == 0) {
                             continue;
                         }
 
                         typedef typename EdgeConfigData::value_type EdgConfigValuetype;
-                        auto value = readPin(i);
+                        auto value = readPin(id);
                         auto edgeConfigMask =
-                            static_cast<EdgConfigValuetype>(1) << i;
+                            static_cast<EdgConfigValuetype>(1) << id;
                         GASSERT(handler_);
                         if (((value) && ((edgeConfig[Edge_Rising] & edgeConfigMask) != 0)) ||
                             ((!value) && ((edgeConfig[Edge_Falling] & edgeConfigMask) != 0))) {
-                            handler_(i, value);
+                            handler_(id, value);
                         }
                     }
                 });


### PR DESCRIPTION
Forcing the compiler should not be used in cmake v3.6 and beyond [ref](https://cmake.org/cmake/help/latest/module/CMakeForceCompiler.html)
